### PR TITLE
Check order by direction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Provides a Laravel API endpoint responder for the `react-dynamic-data-table` component.",
     "require": {
         "php": "^7.0.0",
-        "laravel/framework": "^5.1||^6.0",
+        "laravel/framework": "^5.1||^6.0||^7.0",
         "langleyfoxall/helpers-laravel": "^1.10"
     },
     "autoload": {


### PR DESCRIPTION
This PR ensure that the order by direction received in the request is either `asc` or `desc`. If it is not, an exception will be thrown. This can help mitigate SQL injection vulnerabilities if this variable is used with `orderByRaw` as part of an `overrideOrderByLogic` callable.

Laravel 7 support is also added.