### PR TITLE
Update dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "require": {
         "php": "^7.2||^8.0",
         "laravel/framework": "^5.1||^6.0||^7.0||^8.0",
-        "langleyfoxall/helpers-laravel": "^1.10"
+        "langleyfoxall/helpers-laravel": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I had not realized that there was a cross dependency from here to helpers-laravel.  As a consequence, when I updated this package to support 8.0, it didn't actually unlock 8.0 as the dependency on helpers-laravel is keeping us at 7.x.